### PR TITLE
refactor: remove material-design-icons npm

### DIFF
--- a/apps/material/project.json
+++ b/apps/material/project.json
@@ -6,7 +6,9 @@
   "targets": {
     "build": {
       "executor": "@angular-devkit/build-angular:browser",
-      "outputs": ["{options.outputPath}"],
+      "outputs": [
+        "{options.outputPath}"
+      ],
       "options": {
         "outputPath": "dist/apps/material",
         "index": "apps/material/src/index.html",
@@ -14,8 +16,13 @@
         "polyfills": "apps/material/src/polyfills.ts",
         "tsConfig": "apps/material/tsconfig.app.json",
         "inlineStyleLanguage": "scss",
-        "assets": ["apps/material/src/favicon.ico", "apps/material/src/assets"],
-        "styles": ["apps/material/src/styles.scss"],
+        "assets": [
+          "apps/material/src/favicon.ico",
+          "apps/material/src/assets"
+        ],
+        "styles": [
+          "apps/material/src/styles.scss"
+        ],
         "scripts": []
       },
       "configurations": {
@@ -24,7 +31,7 @@
             {
               "type": "initial",
               "maximumWarning": "500kb",
-              "maximumError": "1mb"
+              "maximumError": "2mb"
             },
             {
               "type": "anyComponentStyle",
@@ -80,12 +87,18 @@
     },
     "test": {
       "executor": "@nrwl/jest:jest",
-      "outputs": ["coverage/apps/material"],
+      "outputs": [
+        "coverage/apps/material"
+      ],
       "options": {
         "jestConfig": "apps/material/jest.config.js",
         "passWithNoTests": true
       }
     }
   },
-  "tags": ["application:", "scope:", "type:app"]
+  "tags": [
+    "application:",
+    "scope:",
+    "type:app"
+  ]
 }

--- a/apps/material/src/index.html
+++ b/apps/material/src/index.html
@@ -6,6 +6,14 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link
+      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <app-root></app-root>

--- a/apps/material/src/styles.scss
+++ b/apps/material/src/styles.scss
@@ -50,61 +50,61 @@
 }
 
 // Material Design Icons
-@font-face {
-  font-family: 'Material Icons';
-  font-style: normal;
-  font-weight: 400;
-  src: url(~material-design-icons/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
-  src: local('Material Icons'), local('MaterialIcons-Regular'),
-    url(~material-design-icons/iconfont/MaterialIcons-Regular.woff2)
-      format('woff2'),
-    url(~material-design-icons/iconfont/MaterialIcons-Regular.woff)
-      format('woff'),
-    url(~material-design-icons/iconfont/MaterialIcons-Regular.ttf)
-      format('truetype');
-}
+// @font-face {
+//   font-family: 'Material Icons';
+//   font-style: normal;
+//   font-weight: 400;
+//   src: url(~material-design-icons/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
+//   src: local('Material Icons'), local('MaterialIcons-Regular'),
+//     url(~material-design-icons/iconfont/MaterialIcons-Regular.woff2)
+//       format('woff2'),
+//     url(~material-design-icons/iconfont/MaterialIcons-Regular.woff)
+//       format('woff'),
+//     url(~material-design-icons/iconfont/MaterialIcons-Regular.ttf)
+//       format('truetype');
+// }
 
-.material-icons {
-  font-family: 'Material Icons';
-  font-weight: normal;
-  font-style: normal;
-  font-size: 24px; /* Preferred icon size */
-  display: inline-block;
-  line-height: 1;
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
+// .material-icons {
+//   font-family: 'Material Icons';
+//   font-weight: normal;
+//   font-style: normal;
+//   font-size: 24px; /* Preferred icon size */
+//   display: inline-block;
+//   line-height: 1;
+//   text-transform: none;
+//   letter-spacing: normal;
+//   word-wrap: normal;
+//   white-space: nowrap;
+//   direction: ltr;
 
-  /* Support for all WebKit browsers. */
-  -webkit-font-smoothing: antialiased;
-  /* Support for Safari and Chrome. */
-  text-rendering: optimizeLegibility;
+//   /* Support for all WebKit browsers. */
+//   -webkit-font-smoothing: antialiased;
+//   /* Support for Safari and Chrome. */
+//   text-rendering: optimizeLegibility;
 
-  /* Support for Firefox. */
-  -moz-osx-font-smoothing: grayscale;
+//   /* Support for Firefox. */
+//   -moz-osx-font-smoothing: grayscale;
 
-  /* Support for IE. */
-  font-feature-settings: 'liga';
-}
+//   /* Support for IE. */
+//   font-feature-settings: 'liga';
+// }
 
-// These helper classes aren't included with Material Icons
-.material-icons.md-18 {
-  font-size: 18px;
-}
-.material-icons.md-24 {
-  font-size: 24px;
-}
-.material-icons.md-36 {
-  font-size: 36px;
-}
-.material-icons.md-48 {
-  font-size: 48px;
-}
+// // These helper classes aren't included with Material Icons
+// .material-icons.md-18 {
+//   font-size: 18px;
+// }
+// .material-icons.md-24 {
+//   font-size: 24px;
+// }
+// .material-icons.md-36 {
+//   font-size: 36px;
+// }
+// .material-icons.md-48 {
+//   font-size: 48px;
+// }
 
-// Roboto font for Material Typography
-$roboto-font-path: '~roboto-fontface/fonts';
-@import '~roboto-fontface/css/roboto/sass/roboto-fontface-light';
-@import '~roboto-fontface/css/roboto/sass/roboto-fontface-regular';
-@import '~roboto-fontface/css/roboto/sass/roboto-fontface-medium';
+// // Roboto font for Material Typography
+// $roboto-font-path: '~roboto-fontface/fonts';
+// @import '~roboto-fontface/css/roboto/sass/roboto-fontface-light';
+// @import '~roboto-fontface/css/roboto/sass/roboto-fontface-regular';
+// @import '~roboto-fontface/css/roboto/sass/roboto-fontface-medium';

--- a/apps/ngrx-ultimate/src/app/nrwl/nrwl.module.ts
+++ b/apps/ngrx-ultimate/src/app/nrwl/nrwl.module.ts
@@ -10,12 +10,12 @@ import { ParamsComponent } from './containers/params/params.component';
 import { effects } from './store/effects';
 
 export const ROUTES: Routes = [
-  { path: '', component: ParentComponent },
-  { path: 'one', component: ChildOneComponent },
-  { path: 'two', component: ChildTwoComponent },
+  { path: '', component: fromContainers.ParentComponent },
+  { path: 'one', component: fromContainers.ChildOneComponent },
+  { path: 'two', component: fromContainers.ChildTwoComponent },
   {
     path: 'params/:paramOne',
-    component: ParentComponent,
+    component: fromContainers.ParentComponent,
     children: [{ path: ':paramTwo', component: ParamsComponent }],
   },
 ];

--- a/apps/ngx-bootstrap/project.json
+++ b/apps/ngx-bootstrap/project.json
@@ -6,7 +6,9 @@
   "targets": {
     "build": {
       "executor": "@angular-devkit/build-angular:browser",
-      "outputs": ["{options.outputPath}"],
+      "outputs": [
+        "{options.outputPath}"
+      ],
       "options": {
         "outputPath": "dist/apps/ngx-bootstrap",
         "index": "apps/ngx-bootstrap/src/index.html",
@@ -18,7 +20,9 @@
           "apps/ngx-bootstrap/src/favicon.ico",
           "apps/ngx-bootstrap/src/assets"
         ],
-        "styles": ["apps/ngx-bootstrap/src/styles.scss"],
+        "styles": [
+          "apps/ngx-bootstrap/src/styles.scss"
+        ],
         "scripts": []
       },
       "configurations": {
@@ -32,7 +36,7 @@
             {
               "type": "anyComponentStyle",
               "maximumWarning": "2kb",
-              "maximumError": "4kb"
+              "maximumError": "6kb"
             }
           ],
           "fileReplacements": [
@@ -83,12 +87,18 @@
     },
     "test": {
       "executor": "@nrwl/jest:jest",
-      "outputs": ["coverage/apps/ngx-bootstrap"],
+      "outputs": [
+        "coverage/apps/ngx-bootstrap"
+      ],
       "options": {
         "jestConfig": "apps/ngx-bootstrap/jest.config.js",
         "passWithNoTests": true
       }
     }
   },
-  "tags": ["application:ngx-bootstrap", "scope:ngx-bootstrap", "type:app"]
+  "tags": [
+    "application:ngx-bootstrap",
+    "scope:ngx-bootstrap",
+    "type:app"
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,10 +38,8 @@
         "bootstrap": "^5.1.3",
         "bootswatch": "^5.1.3",
         "luxon": "^2.3.0",
-        "material-design-icons": "^3.0.1",
         "moment": "^2.29.1",
         "ngx-bootstrap": "^8.0.0",
-        "roboto-fontface": "^0.10.0",
         "rxjs": "~6.6.0",
         "tslib": "^2.0.0",
         "zone.js": "0.11.4"
@@ -15164,11 +15162,6 @@
         "tmpl": "1.0.5"
       }
     },
-    "node_modules/material-design-icons": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/material-design-icons/-/material-design-icons-3.0.1.tgz",
-      "integrity": "sha1-mnHEh0chjrylHlGmbaaCA4zct78="
-    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -17993,11 +17986,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/roboto-fontface": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/roboto-fontface/-/roboto-fontface-0.10.0.tgz",
-      "integrity": "sha512-OlwfYEgA2RdboZohpldlvJ1xngOins5d7ejqnIBWr9KaMxsnBqotpptRXTyfNRLnFpqzX6sTDt+X+a+6udnU8g=="
     },
     "node_modules/run-async": {
       "version": "2.4.1",
@@ -31452,11 +31440,6 @@
         "tmpl": "1.0.5"
       }
     },
-    "material-design-icons": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/material-design-icons/-/material-design-icons-3.0.1.tgz",
-      "integrity": "sha1-mnHEh0chjrylHlGmbaaCA4zct78="
-    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -33547,11 +33530,6 @@
       "requires": {
         "glob": "^7.1.3"
       }
-    },
-    "roboto-fontface": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/roboto-fontface/-/roboto-fontface-0.10.0.tgz",
-      "integrity": "sha512-OlwfYEgA2RdboZohpldlvJ1xngOins5d7ejqnIBWr9KaMxsnBqotpptRXTyfNRLnFpqzX6sTDt+X+a+6udnU8g=="
     },
     "run-async": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -67,10 +67,8 @@
     "bootstrap": "^5.1.3",
     "bootswatch": "^5.1.3",
     "luxon": "^2.3.0",
-    "material-design-icons": "^3.0.1",
     "moment": "^2.29.1",
     "ngx-bootstrap": "^8.0.0",
-    "roboto-fontface": "^0.10.0",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
     "zone.js": "0.11.4"


### PR DESCRIPTION
Including this package was causing a very long 'npm ci' or 'nom install' operation.